### PR TITLE
Add --export arg

### DIFF
--- a/harvey/harvey.py
+++ b/harvey/harvey.py
@@ -44,7 +44,7 @@ with open(abs_file, 'r') as f:
 
 
 def _stripslashes(s):
-  '''removes trailing and leading backslashes from string'''
+  '''Removes trailing and leading backslashes from string'''
   r = re.sub(r"\\(n|r)", "\n", s)
   r = re.sub(r"\\", "", r)
   return r
@@ -58,7 +58,7 @@ def _get_config_name():
 
 
 def _get_licences():
-  """ lists all the licenses on command line """
+  """ Lists all the licenses on command line """
   licenses = _LICENSES
   
   for license in licenses:
@@ -92,7 +92,7 @@ def _get_license_description(license_code):
 
 
 def get_license_summary(license_code):
-  """ Gets the license summary and permitted, forbidden and required behavouir """
+  """ Gets the license summary and permitted, forbidden and required behaviour """
   try:
     abs_file = os.path.join(_ROOT, "summary.json")
     with open(abs_file, 'r') as f:
@@ -136,7 +136,7 @@ def get_license_summary(license_code):
 	
 
 def save_license(license_code):
-  """ Grab license, save to LICENSE/LICENSE.txt file. """
+  """ Grab license, save to LICENSE/LICENSE.txt file """
   desc = _get_license_description(license_code)
   fname = "LICENSE"
   if sys.platform == "win32":
@@ -152,11 +152,11 @@ def main():
   if arguments['ls'] or arguments['list']:
     _get_licences()
   elif arguments['--tldr'] and arguments['<NAME>']:
-    get_license_summary(arguments['<NAME>'])
+    get_license_summary(arguments['<NAME>'].lower())
   elif arguments['--export'] and arguments['<NAME>']:
-    save_license(arguments['<NAME>'])
+    save_license(arguments['<NAME>'].lower())
   elif arguments['<NAME>']:
-    print(_get_license_description(arguments['<NAME>']))
+    print(_get_license_description(arguments['<NAME>'].lower()))
   else:
     print(__doc__)
   

--- a/harvey/harvey.py
+++ b/harvey/harvey.py
@@ -6,6 +6,7 @@ Usage:
   harvey (ls | list)
   harvey <NAME> --tldr
   harvey <NAME>
+  harvey <NAME> --export
   harvey (-h | --help)
   harvey --version
 Options:
@@ -132,6 +133,16 @@ def get_license_summary(license_code):
   except KeyError:
     print(Fore.RED + 'No such license. Please check again.'), 
     print(Style.RESET_ALL),
+	
+
+def save_license(license_code):
+  """ Grab license, save to LICENSE/LICENSE.txt file. """
+  desc = _get_license_description(license_code)
+  fname = "LICENSE"
+  if sys.platform == "win32":
+    fname += ".txt"  # Windows and file exts
+  with open(os.path.join(os.getcwd(), fname), "w") as afile:
+    afile.write(desc)
 
 
 def main():
@@ -142,6 +153,8 @@ def main():
     _get_licences()
   elif arguments['--tldr'] and arguments['<NAME>']:
     get_license_summary(arguments['<NAME>'])
+  elif arguments['--export'] and arguments['<NAME>']:
+    save_license(arguments['<NAME>'])
   elif arguments['<NAME>']:
     print(_get_license_description(arguments['<NAME>']))
   else:


### PR DESCRIPTION
harvey --export %license% is the same as harvey %license% > LICENSE, just a little cleaner.

Also, make license checking case-insensitive (i.e. harvey unlicense, harvey UNLICENSE, harvey UnLicEnSe all produce the same output)
