### PR TITLE
Fix crash with requests v2.8.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 colorama==0.3.3
-docopt==0.6.2
+docopt>=0.6.2
 requests>=2.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 colorama==0.3.3
 docopt==0.6.2
-requests==2.8.0
+requests>=2.8.0

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     },
     install_requires=[
         'docopt>=0.6.2',
-        'requests==2.8.0',
+        'requests>=2.8.0',
         'colorama==0.3.3'
     ],
     entry_points={


### PR DESCRIPTION
To avoid crash like is shown below, when **requests** is major than **2.8.0** version.

``` sh
$ harvey
Traceback (most recent call last):
  File "/usr/lib/python3.5/site-packages/pkg_resources/__init__.py", line 651, in _build_master
    ws.require(__requires__)
  File "/usr/lib/python3.5/site-packages/pkg_resources/__init__.py", line 952, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python3.5/site-packages/pkg_resources/__init__.py", line 844, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (requests 2.8.1 (/usr/lib/python3.5/site-packages), Requirement.parse('requests==2.8.0'), {'harvey'})

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/harvey", line 5, in <module>
    from pkg_resources import load_entry_point
  File "/usr/lib/python3.5/site-packages/pkg_resources/__init__.py", line 3080, in <module>
    @_call_aside
  File "/usr/lib/python3.5/site-packages/pkg_resources/__init__.py", line 3066, in _call_aside
    f(*args, **kwargs)
  File "/usr/lib/python3.5/site-packages/pkg_resources/__init__.py", line 3093, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/lib/python3.5/site-packages/pkg_resources/__init__.py", line 653, in _build_master
    return cls._build_from_requirements(__requires__)
  File "/usr/lib/python3.5/site-packages/pkg_resources/__init__.py", line 666, in _build_from_requirements
    dists = ws.resolve(reqs, Environment())
  File "/usr/lib/python3.5/site-packages/pkg_resources/__init__.py", line 839, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'requests==2.8.0' distribution was not found and is required by harvey
```
