### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ cd harvey/
 $ python setup.py install
 ```
 
-####Note:
+#### Note:
 
 Windows users might need to install [ansicon](https://github.com/adoxa/ansicon) for colorama to work correctly.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
